### PR TITLE
Default to not being an exit relay.

### DIFF
--- a/etc/tor/torrc
+++ b/etc/tor/torrc
@@ -20,6 +20,9 @@ RelayBandwidthBurst 100 MBytes
 SocksPort 0
 SocksPolicy reject *
 
+## Uncomment to become an exit.
+ExitPolicy reject *:*
+
 Log notice file /var/log/tor/notices.log
 DataDirectory /var/lib/tor
 RunAsDaemon 1


### PR DESCRIPTION
If unspecified, relays default to allow exit traffic.
