### PR TITLE
apparmor, tlsdate fix

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,7 +61,7 @@ update-grub
 # install tlsdate
 if [ "$(lsb_release -cs)" == "wheezy" ]; then
 	# tlsdate isn't in wheezy
-	if [ "$((echo 3.5; uname -r) | sort -c 2>&1)" == "" ]; then
+	if [ "$((echo 3.5; uname -r) | sort -cV 2>&1)" == "" ]; then
 		# if we have seccomp (>= linux 3.5) we can backport it
 		if ! grep -q "wheezy-backports" /etc/apt/sources.list; then
 			echo "deb http://ftp.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list


### PR DESCRIPTION
- installs apparmor (will fail gracefully if we can't change the grub cmdline - e.g. on digitalocean)
- adds check that we're running at least kernel 3.5 before installing tlsdate
