### PR TITLE
Fix adding key to apt

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,8 +19,8 @@ apt-get install -y lsb-release apt-transport-https
 if ! grep -q "https://deb.torproject.org/torproject.org" /etc/apt/sources.list; then
     echo "== Adding the official Tor repository"
     echo "deb https://deb.torproject.org/torproject.org `lsb_release -cs` main" >> /etc/apt/sources.list
-    gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
-    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
+    curl 'https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc' > key.asc
+    apt-key add key.asc
     apt-get update
 fi
 


### PR DESCRIPTION
The gpg keyserver has removed the key, and so this script is broken by default. This fixes it for me (on bullseye)